### PR TITLE
Localhost

### DIFF
--- a/src/ui.c
+++ b/src/ui.c
@@ -55,3 +55,4 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrev, LPSTR lpCmdLine, int nC
     }
     return 0;
 }
+

--- a/src/ws_client.c
+++ b/src/ws_client.c
@@ -105,8 +105,10 @@ int main(int argc, char *argv[]) {
     char *test_msg = NULL;
     int headless = 0;
     int chat_log = 0;
-    const char* log_file_name = "chat_log.log";
+    const char *log_file_name = "chat_log.log";
     FILE* file = NULL;
+    char *name = NULL;
+    int name_type = 0;
 
     // Parse args
     if (argc > 2 && strcmp(argv[1], "-m") == 0) {
@@ -114,6 +116,11 @@ int main(int argc, char *argv[]) {
         headless = 1;
     }
 
+    // Id
+    if (argc > 2 && strcmp(argv[1], "-n") == 0) {
+        name_type = 1;
+        name = argv[2];
+    }
 
     if (argc > 1 && strcmp(argv[1], "-s") == 0) {
         printf("Running client with logging\n");
@@ -171,6 +178,17 @@ int main(int argc, char *argv[]) {
 
     printf("WebSocket handshake complete\n");
     fflush(stdout);
+
+    // Send Data to user
+    if (name_type && name) {
+        unsigned char frame[BUFFER_SIZE];
+        char msg[BUFFER_SIZE];
+
+        snprintf(msg, sizeof(msg), "[ID]%s", name);
+
+        int frame_len = ws_encode_frame(msg, strlen(msg), frame);
+        send(sockfd, frame, frame_len, 0);
+    }
 
     // Send test message if in headless mode
     if (headless && test_msg) {
@@ -239,3 +257,4 @@ int main(int argc, char *argv[]) {
     close(sockfd);
     return 0;
 }
+


### PR DESCRIPTION
This pull request introduces several improvements to the WebSocket client and server, focusing on enhanced command-line argument parsing, dynamic host/port configuration, and basic user identification. The client now allows users to specify a name, host, and port, while the server can accept a host address and tracks connected clients with basic identification. These changes make the system more flexible and lay the groundwork for user-specific features.

### Command-line argument parsing and configuration

* The client (`src/ws_client.c`) now supports additional command-line arguments for specifying a user name (`-n`), host (`-h`), and port (`-p`). It also sets sensible defaults for host and port when not provided, improving usability for both cloud and local development.
* The server (`src/ws_server.c`) now parses the host address from command-line arguments, using `getaddrinfo` for resolution and binding, allowing it to listen on any specified interface.

### Dynamic networking

* The client dynamically uses the specified or default host and port for connection and handshake, rather than hardcoded values. This increases deployment flexibility. [[1]](diffhunk://#diff-c061f8dada3d1e1044f54616c9c745a7256576d1214fe5f49b2d978c5b7b22c8L140-R170) [[2]](diffhunk://#diff-c061f8dada3d1e1044f54616c9c745a7256576d1214fe5f49b2d978c5b7b22c8L162-R195)
* The server uses the resolved host address for binding and displays the correct bound address in its startup message.

### User identification

* Added a `Client` struct to the server to track client IDs and names. The server initializes each new client with a default name and updates the name when receiving a special `[ID]` message from the client. [[1]](diffhunk://#diff-10baa2fe699c0ff9b7672fcd4b40135425eea1ec9780f78d33b9ca9e62a037ffR10-R21) [[2]](diffhunk://#diff-10baa2fe699c0ff9b7672fcd4b40135425eea1ec9780f78d33b9ca9e62a037ffR171-R176) [[3]](diffhunk://#diff-10baa2fe699c0ff9b7672fcd4b40135425eea1ec9780f78d33b9ca9e62a037ffR251-R260)
* The client sends its name to the server after handshake if provided, using a `[ID]` message frame.

### Minor code cleanups

* Removed unused or redundant code, such as old argument parsing logic and unnecessary hardcoded values. [[1]](diffhunk://#diff-c061f8dada3d1e1044f54616c9c745a7256576d1214fe5f49b2d978c5b7b22c8R110-R150) [[2]](diffhunk://#diff-10baa2fe699c0ff9b7672fcd4b40135425eea1ec9780f78d33b9ca9e62a037ffR95-R145)
* Added blank lines at the end of `WinMain` and `main` functions for style consistency. [[1]](diffhunk://#diff-f9268afceed51a37582ed03b2f03507f6448defc54ff8ca2b158cfc7685601bbR58) [[2]](diffhunk://#diff-c061f8dada3d1e1044f54616c9c745a7256576d1214fe5f49b2d978c5b7b22c8R282)